### PR TITLE
Update starter.rs in the Constants challenge with helpful note to declare constant outside main

### DIFF
--- a/challenges/constants/src/starter.rs
+++ b/challenges/constants/src/starter.rs
@@ -1,4 +1,5 @@
 // Define a constant MAX_SIZE with a value of 100.
+// NOTE: Define the constant outside the main function
 // Your code here
 
 pub fn main() -> i32 {


### PR DESCRIPTION
A beginner(like me) will usually declare the constant inside the "main" function. Like so.

```rust
pub fn main() -> i32 {
    const MAX_SIZE: i32 = 100;
    return MAX_SIZE;
}
```

Which will cause a test to fail and show the following error

```
---- tests::test_constants stdout ----
thread 'tests::test_constants' panicked at challenges/playground/tests/tests.rs:40:9:
Expected constant MAX_SIZE to exist
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
failures:
    tests::test_constants
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
error: test failed, to rerun pass `--test tests`
---
```

From the error message "Expected constant MAX_SIZE to exist", this is probably because the scope of the constant is limited to the main function and so the test method is unable to access it. 

So adding a helpful note in the code should help a beginner avoid the test failure error message that would discourage them from going forward in the course.