### PR TITLE
Add test case for negative to positive range

### DIFF
--- a/challenges/find-the-first-palindrome/tests/tests.rs
+++ b/challenges/find-the-first-palindrome/tests/tests.rs
@@ -26,4 +26,9 @@ mod tests {
     fn test_find_first_palindrome_edge_case() {
         assert_eq!(find_first_palindrome(1, 1), Some(1));
     }
+
+    #[test]
+    fn test_find_first_palindrome_negative_range() {
+        assert_eq!(find_first_palindrome(-1, 1), Some(0));
+    }
 }


### PR DESCRIPTION
The first possible palindrome is `0`, illustrate that with a range going from -1 to 1.