### PR TITLE
Fix: derive Debug for AppConfig in Default trait exercise

### DIFF
--- a/challenges/the-default-trait/src/starter.rs
+++ b/challenges/the-default-trait/src/starter.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct AppConfig {
     pub theme: String,
     pub notifications_enabled: bool,


### PR DESCRIPTION
Hello!

I was working on the "The Default Trait" exercise and thought I could provide a small user experience adjustment.
The example in the main function tries to print the config using `{:?}`, but since `AppConfig` didn't have `Debug` derived, it throws a compilation error. I've just added `#[derive(Debug)]` to the struct so that learners can focus purely on implementing the `Default` and prevent a first compilation that might obviously fail.

I'm really enjoying the project, thanks for all the hard work on these exercises! Hope this helps!