### PR TITLE
Fix sentence error in exercise "Animal sanctuary registry"

### DIFF
--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type is provided, which uses a **hashing algorithm** called **SipHash** to store keys and values in a way that allows for **fast and secure** lookups. Think of them as a dictionary in Python or an object in JavaScript.
+Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type is implemented using a **hashing algorithm** called **SipHash** to store keys and values in a way that allows for **fast and secure** lookups. Think of them as a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store the keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
+Hash maps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store the keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type uses a **hashing algorithm** to store keys and values, allowing for fast lookups. By default, Rust uses **SipHash**, a hashing algorithm that protects against hashing collision attacks and potentially malicious inputs. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
+Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type uses a **hashing algorithm** to store keys and values, allowing for fast lookups. By default, Rust uses **SipHash**, a hashing algorithm that protects against hashing collision attacks and potentially malicious inputs, making lookups both fast and secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hash maps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store the keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
+Hash maps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type is implemented using a **hashing algorithm** called **SipHash** to store keys and values in a way that allows for **fast and secure** lookups. Think of them as a dictionary in Python or an object in JavaScript.
+Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type uses a **hashing algorithm** to store keys and values, allowing for fast lookups. By default, Rust uses **SipHash**, a hashing algorithm that protects against hashing collision attacks and potentially malicious inputs. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type uses a **hashing algorithm** to store keys and values, allowing for fast lookups. By default, Rust uses **SipHash**, a hashing algorithm that protects against hashing collision attacks and potentially malicious inputs, making lookups both fast and secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
+Hashmaps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store the keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 

--- a/challenges/animal-sanctuary-registry/description.md
+++ b/challenges/animal-sanctuary-registry/description.md
@@ -1,6 +1,6 @@
 ## Hashmaps
 
-Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type is provided that uses the a **hashing algorithm** called **SipHash** to store keys and values in a way that allows for **fast and secure** lookups. Think of them as a dictionary in Python or an object in JavaScript.
+Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type is provided, which uses a **hashing algorithm** called **SipHash** to store keys and values in a way that allows for **fast and secure** lookups. Think of them as a dictionary in Python or an object in JavaScript.
 
 In this challenge, we want to build a sanctuary registry that allows us to manage animals in different sections of the sanctuary. We'll use a `HashMap` to store the sections as keys and a `Vec` to store the animals in each section. Each key is a section name `String` and each value is a list of animals in that section `Vec<String>`.
 


### PR DESCRIPTION
Original paragraph:

> Hashmaps are a powerful data structure that allow you to store key-value pairs. In Rust, the HashMap type is provided that uses the a hashing algorithm called SipHash to store keys and values in a way that allows for fast and secure lookups. Think of them as a dictionary in Python or an object in JavaScript.

There is a sentence which contains a typo:
> ...uses THE A hashing algorithm called...

And also a grammatical error:
> the HashMap type is provided THAT uses...

First commit fixes both errors (replacing 'that' with 'which' and choosing the indefinite article 'a' and removing the definite one). Producing:

> (...) In Rust, the `HashMap` type is provided, which uses a **hashing algorithm** called **SipHash** (...)

The second commit slightly rephrases the sentence to avoid using the passive "is provided":

> (...) In Rust, the `HashMap` type is implemented using a **hashing algorithm** called **SipHash** (...)

Which in my opinion is clearer (because we already know from the previous exercise that the HashMap type is provided in Rust so maybe there's no need to use the word "provided" here).

The third commit kinda rephrases the whole paragraph to make it more clear and also more technically accurate (but I could be wrong as I am not a Rust expert which is why I am on Rustfinity):

> Hashmaps are a powerful data structure that allow you to store **key-value pairs**. In Rust, the `HashMap` type uses a **hashing algorithm** to store keys and values, allowing for fast lookups. By default, Rust uses **SipHash**, a hashing algorithm that protects against hashing collision attacks and potentially malicious inputs. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.

The fourth commit simply explicitly says that the default hashing algorithm used in Rust (unlike in most other programming languages) is designed to be secure and not only fast. It is already obvious but saying it explicitly maybe makes it easier for beginners to get familiar with Rust design philosophy.

> (...) that protects against (...), making lookups both fast and secure.

The fifth commit is about making it clearer for beginners (that may not familiar with hash maps) that the way in which the keys and values are internally stored is important.

> Hashmaps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store the keys and values in a specific, organized way, which allows fast lookups. 

The other 2 commits are minor grammatical improvements. 

The FINAL proposed version is:

> Hash maps are a powerful data structure that allow you to store **key-value pairs**. Internally the `HashMap` type uses a **hashing algorithm** to store keys and values in a specific, organized way, which allows fast lookups. By default, Rust uses **SipHash**, an algorithm that protects against hash collision attacks and potentially malicious inputs, making lookups not only fast but also secure. Conceptually, you can think of a `HashMap` like a dictionary in Python or an object in JavaScript.
