### PR TITLE
Modify requirements for OrderStatus enum derives

### DIFF
--- a/challenges/derive-partial-eq/description.md
+++ b/challenges/derive-partial-eq/description.md
@@ -20,7 +20,8 @@ In this challenge, you'll define a simple enum and use `#[derive(PartialEq)]` to
 ### Requirements
 
 1. Use the `#[derive(PartialEq)]` macro for the `OrderStatus` enum.
-2. Write tests to verify the equality and inequality of the enum variants.
+2. Use `#[derive(Debug)]` so that the OrderStatus enum can be printed in a developer-friendly way
+3. Write tests to verify the equality and inequality of the enum variants.
 
 ## Hints
 
@@ -29,5 +30,14 @@ In this challenge, you'll define a simple enum and use `#[derive(PartialEq)]` to
 
 - Use the `derive` macro on the enum to automatically implement `PartialEq`.
 - String types in Rust already implement `PartialEq`, so `Cancelled(String)` can be compared automatically.
+
+</details>
+
+## Tips
+
+<details>
+   <summary>Click here to reveal tips</summary>
+
+- Instead of adding the `#[derive(PartialEq)]` and `#[derive(Debug)]` macros on two separate lines, they can be added together like this `#[derive(Debug, PartialEq)]`
 
 </details>


### PR DESCRIPTION
Updated requirements to include Debug derive for OrderStatus enum and combined derive macros tips.

If you leave out Debug derive, it will throw an error like this

```sh
   Compiling derive-partial-eq v0.1.0 (/app/challenges/playground)
error[E0277]: `OrderStatus` doesn't implement `Debug`
  --> challenges/playground/src/lib.rs:15:5
   |
15 |     assert_eq!(status1, status2);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `OrderStatus`
   |
   = note: add `#[derive(Debug)]` to `OrderStatus` or manually `impl Debug for OrderStatus`
   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `OrderStatus` with `#[derive(Debug)]`
   |
 5 + #[derive(Debug)]
 6 | pub enum OrderStatus {
   |
error[E0277]: `OrderStatus` doesn't implement `Debug`
  --> challenges/playground/src/lib.rs:19:5
   |
19 |     assert_eq!(cancelled1, cancelled2);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `OrderStatus`
   |
   = note: add `#[derive(Debug)]` to `OrderStatus` or manually `impl Debug for OrderStatus`
   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `OrderStatus` with `#[derive(Debug)]`
   |
 5 + #[derive(Debug)]
 6 | pub enum OrderStatus {
   |
error[E0277]: `OrderStatus` doesn't implement `Debug`
  --> challenges/playground/src/lib.rs:22:5
   |
22 |     assert_ne!(cancelled1, cancelled3);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `OrderStatus`
   |
   = note: add `#[derive(Debug)]` to `OrderStatus` or manually `impl Debug for OrderStatus`
   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `OrderStatus` with `#[derive(Debug)]`
   |
 5 + #[derive(Debug)]
 6 | pub enum OrderStatus {
   |
For more information about this error, try `rustc --explain E0277`.
error: could not compile `derive-partial-eq` (lib) due to 6 previous errors
```

Feel free to modify as you see fit since I am still learning rust and the way I presented the requirements and the tips might not fit the expected standard

Cheers