### PR TITLE
Strengthen `test_add_duplicate_student` to detect overwrites in student-grades-tracker

### DIFF
--- a/challenges/student-grades-tracker/tests/tests.rs
+++ b/challenges/student-grades-tracker/tests/tests.rs
@@ -11,9 +11,11 @@ fn test_add_student() {
 fn test_add_duplicate_student() {
     let mut tracker = StudentGrades::new();
     tracker.add_student("Alice");
+    tracker.students.get_mut("Alice").unwrap().name = "Original Alice".to_string();
     tracker.add_student("Alice"); // Adding a duplicate student should not overwrite
     assert_eq!(tracker.students.len(), 1);
     assert!(tracker.students.contains_key("Alice"));
+    assert_eq!(tracker.students.get("Alice").unwrap().name, "Original Alice");
 }
 
 #[test]


### PR DESCRIPTION
Fix `test_add_duplicate_student` so that it properly checks for overwrites.

Adding a duplicate student should not overwrite.
**A solution like the following should not pass:**
```rust
use std::collections::HashMap;

pub struct Student {
    pub name: String,
    pub grades: Vec<u8>,
}

pub struct StudentGrades {
    pub students: HashMap<String, Student>,
}

impl StudentGrades {
    pub fn new() -> Self {
        Self {
            students: HashMap::new(),
        }
    }

// -----------------------------
// PROBLEMATIC CODE
    pub fn add_student(&mut self, name: &str) {
        // Here insert overwrites grades
        self.students.insert(
            name.to_string(),
            Student {
                name: name.to_string(),
                grades: vec![]
            }
        );
    }
// -----------------------------

    pub fn add_grade(&mut self, name: &str, grade: u8) {
        if let Some(student) = self.students.get_mut(name) {
            student.grades.push(grade);
        }
    }

    pub fn get_grades(&self, name: &str) -> &[u8] {
        if let Some(student) = self.students.get(name) {
            student.grades.as_slice()
        } else {
            &[]
        }
    }
}
```